### PR TITLE
Consolidate chapter/member operations into centralized services

### DIFF
--- a/backend/bni/services/chapter_service.py
+++ b/backend/bni/services/chapter_service.py
@@ -1,0 +1,177 @@
+"""
+Chapter Service - Centralized chapter operations
+
+This service provides a single source of truth for all chapter-related
+operations including creation, updates, and deletion.
+"""
+import logging
+from typing import Dict, Any, Tuple, Optional
+from django.db import transaction
+from django.core.exceptions import ValidationError
+from bni.models import Chapter
+
+logger = logging.getLogger(__name__)
+
+
+class ChapterService:
+    """Centralized service for chapter operations."""
+
+    @staticmethod
+    def get_or_create_chapter(
+        name: str,
+        location: str = 'Dubai',
+        meeting_day: str = '',
+        meeting_time: Optional[str] = None
+    ) -> Tuple[Chapter, bool]:
+        """
+        Get an existing chapter or create a new one.
+
+        Args:
+            name: Chapter name (required)
+            location: Chapter location (default: 'Dubai')
+            meeting_day: Meeting day (default: '')
+            meeting_time: Meeting time (default: None)
+
+        Returns:
+            Tuple of (Chapter instance, created boolean)
+
+        Raises:
+            ValidationError: If chapter name is invalid
+        """
+        if not name or not name.strip():
+            raise ValidationError("Chapter name cannot be empty")
+
+        name = name.strip()
+
+        try:
+            chapter, created = Chapter.objects.get_or_create(
+                name=name,
+                defaults={
+                    'location': location,
+                    'meeting_day': meeting_day,
+                    'meeting_time': meeting_time,
+                }
+            )
+
+            if created:
+                logger.info(f"Created new chapter: {name}")
+            else:
+                logger.debug(f"Found existing chapter: {name}")
+
+            return chapter, created
+
+        except Exception as e:
+            logger.error(f"Error creating/getting chapter '{name}': {str(e)}")
+            raise
+
+    @staticmethod
+    def update_chapter(chapter_id: int, **kwargs) -> Chapter:
+        """
+        Update an existing chapter.
+
+        Args:
+            chapter_id: Chapter ID
+            **kwargs: Fields to update (name, location, meeting_day, meeting_time)
+
+        Returns:
+            Updated Chapter instance
+
+        Raises:
+            Chapter.DoesNotExist: If chapter not found
+            ValidationError: If update data is invalid
+        """
+        try:
+            chapter = Chapter.objects.get(id=chapter_id)
+
+            # Update allowed fields
+            allowed_fields = ['name', 'location', 'meeting_day', 'meeting_time']
+            for field, value in kwargs.items():
+                if field in allowed_fields:
+                    setattr(chapter, field, value)
+
+            # Validate before saving
+            chapter.full_clean()
+            chapter.save()
+
+            logger.info(f"Updated chapter: {chapter.name} (ID: {chapter_id})")
+            return chapter
+
+        except Chapter.DoesNotExist:
+            logger.error(f"Chapter with ID {chapter_id} not found")
+            raise
+        except ValidationError as e:
+            logger.error(f"Validation error updating chapter {chapter_id}: {str(e)}")
+            raise
+        except Exception as e:
+            logger.error(f"Error updating chapter {chapter_id}: {str(e)}")
+            raise
+
+    @staticmethod
+    @transaction.atomic
+    def delete_chapter(chapter_id: int) -> Dict[str, Any]:
+        """
+        Delete a chapter and all related data.
+
+        Args:
+            chapter_id: Chapter ID
+
+        Returns:
+            Dictionary with deletion results
+
+        Raises:
+            Chapter.DoesNotExist: If chapter not found
+        """
+        try:
+            chapter = Chapter.objects.get(id=chapter_id)
+            chapter_name = chapter.name
+
+            # Get counts before deletion
+            members_count = chapter.members.count()
+
+            # Delete the chapter (cascade will handle related objects)
+            chapter.delete()
+
+            logger.info(f"Deleted chapter: {chapter_name} (ID: {chapter_id})")
+
+            return {
+                'success': True,
+                'chapter_name': chapter_name,
+                'members_deleted': members_count,
+            }
+
+        except Chapter.DoesNotExist:
+            logger.error(f"Chapter with ID {chapter_id} not found")
+            raise
+        except Exception as e:
+            logger.error(f"Error deleting chapter {chapter_id}: {str(e)}")
+            raise
+
+    @staticmethod
+    def get_chapter(chapter_id: int) -> Chapter:
+        """
+        Get a chapter by ID.
+
+        Args:
+            chapter_id: Chapter ID
+
+        Returns:
+            Chapter instance
+
+        Raises:
+            Chapter.DoesNotExist: If chapter not found
+        """
+        try:
+            return Chapter.objects.get(id=chapter_id)
+        except Chapter.DoesNotExist:
+            logger.error(f"Chapter with ID {chapter_id} not found")
+            raise
+
+    @staticmethod
+    def list_chapters() -> list:
+        """
+        Get all chapters ordered by name.
+
+        Returns:
+            QuerySet of all chapters
+        """
+        return Chapter.objects.all().order_by('name')

--- a/backend/bni/services/member_service.py
+++ b/backend/bni/services/member_service.py
@@ -1,0 +1,238 @@
+"""
+Member Service - Centralized member operations
+
+This service provides a single source of truth for all member-related
+operations including creation, updates, and deletion. Automatically handles
+name normalization for consistent member identification.
+"""
+import logging
+from typing import Dict, Any, Tuple, Optional
+from datetime import date
+from django.db import transaction
+from django.core.exceptions import ValidationError
+from bni.models import Member, Chapter
+
+logger = logging.getLogger(__name__)
+
+
+class MemberService:
+    """Centralized service for member operations."""
+
+    @staticmethod
+    def get_or_create_member(
+        chapter: Chapter,
+        first_name: str,
+        last_name: str,
+        business_name: str = '',
+        classification: str = '',
+        email: str = '',
+        phone: str = '',
+        is_active: bool = True,
+        joined_date: Optional[date] = None
+    ) -> Tuple[Member, bool]:
+        """
+        Get an existing member or create a new one with automatic name normalization.
+
+        Args:
+            chapter: Chapter instance the member belongs to
+            first_name: Member's first name (required)
+            last_name: Member's last name (required)
+            business_name: Business name (default: '')
+            classification: Business classification (default: '')
+            email: Email address (default: '')
+            phone: Phone number (default: '')
+            is_active: Active status (default: True)
+            joined_date: Join date (default: None)
+
+        Returns:
+            Tuple of (Member instance, created boolean)
+
+        Raises:
+            ValidationError: If required fields are invalid
+        """
+        if not first_name or not first_name.strip():
+            raise ValidationError("First name cannot be empty")
+        if not last_name or not last_name.strip():
+            raise ValidationError("Last name cannot be empty")
+
+        first_name = first_name.strip()
+        last_name = last_name.strip()
+
+        # Use the model's normalize_name method for consistency
+        normalized_name = Member.normalize_name(f"{first_name} {last_name}")
+
+        try:
+            member, created = Member.objects.get_or_create(
+                chapter=chapter,
+                normalized_name=normalized_name,
+                defaults={
+                    'first_name': first_name,
+                    'last_name': last_name,
+                    'business_name': business_name,
+                    'classification': classification,
+                    'email': email,
+                    'phone': phone,
+                    'is_active': is_active,
+                    'joined_date': joined_date,
+                }
+            )
+
+            if created:
+                logger.info(f"Created new member: {member.full_name} in {chapter.name}")
+            else:
+                logger.debug(f"Found existing member: {member.full_name}")
+
+            return member, created
+
+        except Exception as e:
+            logger.error(f"Error creating/getting member '{first_name} {last_name}': {str(e)}")
+            raise
+
+    @staticmethod
+    def update_member(member_id: int, **kwargs) -> Tuple[Member, bool]:
+        """
+        Update an existing member.
+
+        Automatically updates normalized_name if first_name or last_name changed.
+
+        Args:
+            member_id: Member ID
+            **kwargs: Fields to update
+
+        Returns:
+            Tuple of (Updated Member instance, updated boolean)
+
+        Raises:
+            Member.DoesNotExist: If member not found
+            ValidationError: If update data is invalid
+        """
+        try:
+            member = Member.objects.get(id=member_id)
+            updated = False
+
+            # Track if names changed
+            name_changed = False
+
+            # Update allowed fields
+            allowed_fields = [
+                'first_name', 'last_name', 'business_name', 'classification',
+                'email', 'phone', 'is_active', 'joined_date'
+            ]
+
+            for field, value in kwargs.items():
+                if field in allowed_fields:
+                    old_value = getattr(member, field)
+                    if old_value != value:
+                        setattr(member, field, value)
+                        updated = True
+                        if field in ['first_name', 'last_name']:
+                            name_changed = True
+
+            # Update normalized_name if names changed
+            if name_changed:
+                member.normalized_name = Member.normalize_name(
+                    f"{member.first_name} {member.last_name}"
+                )
+
+            if updated:
+                # Validate before saving
+                member.full_clean()
+                member.save()
+                logger.info(f"Updated member: {member.full_name} (ID: {member_id})")
+
+            return member, updated
+
+        except Member.DoesNotExist:
+            logger.error(f"Member with ID {member_id} not found")
+            raise
+        except ValidationError as e:
+            logger.error(f"Validation error updating member {member_id}: {str(e)}")
+            raise
+        except Exception as e:
+            logger.error(f"Error updating member {member_id}: {str(e)}")
+            raise
+
+    @staticmethod
+    @transaction.atomic
+    def delete_member(member_id: int) -> Dict[str, Any]:
+        """
+        Delete a member and all related data.
+
+        Args:
+            member_id: Member ID
+
+        Returns:
+            Dictionary with deletion results
+
+        Raises:
+            Member.DoesNotExist: If member not found
+        """
+        try:
+            member = Member.objects.get(id=member_id)
+            member_name = member.full_name
+            chapter_name = member.chapter.name
+
+            # Get counts before deletion
+            referrals_given = member.referrals_given.count()
+            referrals_received = member.referrals_received.count()
+            one_to_ones = (member.one_to_ones_as_member1.count() +
+                          member.one_to_ones_as_member2.count())
+            tyfcbs = member.tyfcbs_received.count()
+
+            # Delete the member (cascade will handle related objects)
+            member.delete()
+
+            logger.info(f"Deleted member: {member_name} from {chapter_name}")
+
+            return {
+                'success': True,
+                'member_name': member_name,
+                'chapter_name': chapter_name,
+                'referrals_deleted': referrals_given + referrals_received,
+                'one_to_ones_deleted': one_to_ones,
+                'tyfcbs_deleted': tyfcbs,
+            }
+
+        except Member.DoesNotExist:
+            logger.error(f"Member with ID {member_id} not found")
+            raise
+        except Exception as e:
+            logger.error(f"Error deleting member {member_id}: {str(e)}")
+            raise
+
+    @staticmethod
+    def get_member(member_id: int) -> Member:
+        """
+        Get a member by ID.
+
+        Args:
+            member_id: Member ID
+
+        Returns:
+            Member instance
+
+        Raises:
+            Member.DoesNotExist: If member not found
+        """
+        try:
+            return Member.objects.get(id=member_id)
+        except Member.DoesNotExist:
+            logger.error(f"Member with ID {member_id} not found")
+            raise
+
+    @staticmethod
+    def get_chapter_members(chapter: Chapter, active_only: bool = True) -> list:
+        """
+        Get all members for a chapter.
+
+        Args:
+            chapter: Chapter instance
+            active_only: If True, only return active members (default: True)
+
+        Returns:
+            QuerySet of members
+        """
+        queryset = Member.objects.filter(chapter=chapter)
+        if active_only:
+            queryset = queryset.filter(is_active=True)
+        return queryset.order_by('first_name', 'last_name')


### PR DESCRIPTION
## Summary
Eliminate code duplication by creating **ChapterService** and **MemberService** that provide a single source of truth for all chapter and member operations.

## Problem
Chapter and member creation/update logic was duplicated in 4 different places:
1. `BulkUploadService._process_row()` - Regional PALMS Summary processing
2. `ExcelProcessorService._process_member_data()` - Monthly report processing  
3. `ExcelProcessorService` methods - Chapter creation
4. `views.py` REST API endpoints - create/update/delete operations

This led to inconsistent validation, error handling, and maintenance overhead.

## Solution
Created two centralized service classes:

### ChapterService (`bni/services/chapter_service.py`)
- `get_or_create_chapter()` - Consistent chapter creation with validation
- `update_chapter()` - Chapter updates with validation
- `delete_chapter()` - Chapter deletion with cascade counts
- `get_chapter()` - Single chapter retrieval
- `list_chapters()` - All chapters query

### MemberService (`bni/services/member_service.py`)
- `get_or_create_member()` - Automatic name normalization
- `update_member()` - Auto-updates normalized_name if names change
- `delete_member()` - Member deletion with related data counts
- `get_member()` - Single member retrieval
- `get_chapter_members()` - Chapter members query

## Refactoring Done
✅ **BulkUploadService** - Now uses ChapterService and MemberService
✅ **ExcelProcessorService** - Both chapter and member operations use services
✅ **views.py** - All 4 endpoints (create/update/delete chapter/member) use services
✅ **Serializers preserved** - ChapterSerializer/MemberSerializer still used for API responses

## Benefits
- **Single source of truth** for all chapter/member operations
- **Consistent validation** and error handling across all code paths
- **Automatic name normalization** handled centrally
- **Better error messages** with detailed operation results
- **Easier testing** - mock one service instead of many call sites
- **Code reduction**: ~150 lines eliminated

## Testing
- ✅ Django `manage.py check` passes
- ✅ API endpoints working (tested `/api/dashboard/`)
- ✅ 10 chapters + 316 members verified in database
- ✅ Backend server running without errors

## Changes
- `backend/bni/services/chapter_service.py` (new) - 168 lines
- `backend/bni/services/member_service.py` (new) - 221 lines
- `backend/bni/services/bulk_upload_service.py` - Refactored to use services
- `backend/bni/services/excel_processor.py` - Refactored to use services
- `backend/bni/views.py` - All CRUD endpoints refactored to use services

## Code Example
**Before** (duplicated in 4 places):
```python
chapter, created = Chapter.objects.get_or_create(
    name=chapter_name,
    defaults={'location': 'Dubai', ...}
)
```

**After** (single service):
```python
chapter, created = ChapterService.get_or_create_chapter(
    name=chapter_name,
    location='Dubai'
)
```