### PR TITLE
Phase 2: Convert function-based views to ViewSets with RESTful routing

### DIFF
--- a/backend/analytics/views.py
+++ b/backend/analytics/views.py
@@ -1,3 +1,430 @@
-from django.shortcuts import render
+"""
+Analytics ViewSet - RESTful API for Matrix data and Comparisons
+"""
+from rest_framework import viewsets, status
+from rest_framework.decorators import action
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
 
-# Create your views here.
+from chapters.models import Chapter
+from reports.models import MonthlyReport
+from bni.services.comparison_service import ComparisonService
+
+
+class MatrixViewSet(viewsets.ViewSet):
+    """
+    ViewSet for Matrix operations.
+
+    Provides endpoints for:
+    - Referral matrix with totals
+    - One-to-one matrix with totals
+    - Combination matrix with summaries
+    """
+    permission_classes = [AllowAny]  # TODO: Add proper authentication
+
+    @action(detail=False, methods=['get'], url_path='referral')
+    def referral_matrix(self, request, chapter_id=None, report_id=None):
+        """
+        Return referral matrix for a specific monthly report.
+
+        Returns pre-processed matrix data with calculated summary columns:
+        - given: Total referrals given by each member
+        - received: Total referrals received by each member
+        - unique_given: Number of unique members given referrals to
+        - unique_received: Number of unique members received referrals from
+        """
+        try:
+            chapter = Chapter.objects.get(id=chapter_id)
+            monthly_report = MonthlyReport.objects.get(id=report_id, chapter=chapter)
+
+            # Return the pre-processed matrix data with calculated summaries
+            result = monthly_report.referral_matrix_data
+
+            # Add calculated summary columns if data exists
+            if result and 'members' in result and 'matrix' in result:
+                members = result['members']
+                matrix = result['matrix']
+
+                # Calculate totals for referral matrix
+                totals = {
+                    'given': {},
+                    'received': {},
+                    'unique_given': {},
+                    'unique_received': {}
+                }
+
+                # Calculate row totals (given)
+                for i, giver in enumerate(members):
+                    row_total = 0
+                    unique_count = 0
+                    for j, value in enumerate(matrix[i] if i < len(matrix) else []):
+                        if value and isinstance(value, (int, float)):
+                            row_total += value
+                            if value > 0:
+                                unique_count += 1
+                    totals['given'][giver] = row_total
+                    totals['unique_given'][giver] = unique_count
+
+                # Calculate column totals (received)
+                for j, receiver in enumerate(members):
+                    col_total = 0
+                    unique_count = 0
+                    for i in range(len(matrix)):
+                        if j < len(matrix[i]):
+                            value = matrix[i][j]
+                            if value and isinstance(value, (int, float)):
+                                col_total += value
+                                if value > 0:
+                                    unique_count += 1
+                    totals['received'][receiver] = col_total
+                    totals['unique_received'][receiver] = unique_count
+
+                result['totals'] = totals
+
+            return Response(result)
+
+        except (Chapter.DoesNotExist, MonthlyReport.DoesNotExist):
+            return Response(
+                {'error': 'Chapter or monthly report not found'},
+                status=status.HTTP_404_NOT_FOUND
+            )
+        except Exception as e:
+            return Response(
+                {'error': f'Matrix generation failed: {str(e)}'},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
+    @action(detail=False, methods=['get'], url_path='one-to-one')
+    def one_to_one_matrix(self, request, chapter_id=None, report_id=None):
+        """
+        Return one-to-one matrix for a specific monthly report.
+
+        Returns pre-processed matrix data with calculated summary columns:
+        - given: Total OTOs initiated by each member
+        - received: Total OTOs received by each member
+        - unique_given: Number of unique members had OTOs with (as initiator)
+        - unique_received: Number of unique members had OTOs with (as receiver)
+        """
+        try:
+            chapter = Chapter.objects.get(id=chapter_id)
+            monthly_report = MonthlyReport.objects.get(id=report_id, chapter=chapter)
+
+            # Return the pre-processed matrix data with calculated summaries
+            result = monthly_report.oto_matrix_data
+
+            # Add calculated summary columns if data exists
+            if result and 'members' in result and 'matrix' in result:
+                members = result['members']
+                matrix = result['matrix']
+
+                # Calculate totals for OTO matrix
+                totals = {
+                    'given': {},
+                    'received': {},
+                    'unique_given': {},
+                    'unique_received': {}
+                }
+
+                # Calculate row totals (given)
+                for i, giver in enumerate(members):
+                    row_total = 0
+                    unique_count = 0
+                    for j, value in enumerate(matrix[i] if i < len(matrix) else []):
+                        if value and isinstance(value, (int, float)):
+                            row_total += value
+                            if value > 0:
+                                unique_count += 1
+                    totals['given'][giver] = row_total
+                    totals['unique_given'][giver] = unique_count
+
+                # Calculate column totals (received)
+                for j, receiver in enumerate(members):
+                    col_total = 0
+                    unique_count = 0
+                    for i in range(len(matrix)):
+                        if j < len(matrix[i]):
+                            value = matrix[i][j]
+                            if value and isinstance(value, (int, float)):
+                                col_total += value
+                                if value > 0:
+                                    unique_count += 1
+                    totals['received'][receiver] = col_total
+                    totals['unique_received'][receiver] = unique_count
+
+                result['totals'] = totals
+
+            return Response(result)
+
+        except (Chapter.DoesNotExist, MonthlyReport.DoesNotExist):
+            return Response(
+                {'error': 'Chapter or monthly report not found'},
+                status=status.HTTP_404_NOT_FOUND
+            )
+        except Exception as e:
+            return Response(
+                {'error': f'Matrix generation failed: {str(e)}'},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
+    @action(detail=False, methods=['get'], url_path='combination')
+    def combination_matrix(self, request, chapter_id=None, report_id=None):
+        """
+        Return combination matrix for a specific monthly report.
+
+        Returns matrix showing which members have both referrals and OTOs.
+        Values use numeric mapping:
+        - 0 (or empty): Neither
+        - 1: OTO only
+        - 2: Referral only
+        - 3: Both
+
+        Includes summary counts for each category per member.
+        """
+        try:
+            chapter = Chapter.objects.get(id=chapter_id)
+            monthly_report = MonthlyReport.objects.get(id=report_id, chapter=chapter)
+
+            # Return the pre-processed matrix data with calculated summaries
+            result = monthly_report.combination_matrix_data
+
+            # Add calculated summary columns if data exists
+            if result and 'members' in result and 'matrix' in result:
+                members = result['members']
+                matrix = result['matrix']
+
+                # Calculate combination counts for each member using simple numeric mapping
+                # - (empty/0) = Neither, 1 = OTO only, 2 = Referral only, 3 = Both
+                summaries = {
+                    'neither': {},
+                    'oto_only': {},
+                    'referral_only': {},
+                    'both': {}
+                }
+
+                for i, member in enumerate(members):
+                    neither_count = 0
+                    oto_only_count = 0
+                    referral_only_count = 0
+                    both_count = 0
+
+                    row_data = matrix[i] if i < len(matrix) else []
+                    for j, value in enumerate(row_data):
+                        if i != j:  # Don't count self-relationships
+                            # Convert value to integer for comparison
+                            if isinstance(value, str):
+                                if value == '-' or value == '' or value == '0':
+                                    int_value = 0
+                                else:
+                                    try:
+                                        int_value = int(value)
+                                    except (ValueError, TypeError):
+                                        int_value = 0
+                            elif isinstance(value, (int, float)):
+                                int_value = int(value)
+                            else:
+                                int_value = 0
+
+                            # Count based on simple numeric mapping
+                            if int_value == 0:
+                                neither_count += 1
+                            elif int_value == 1:
+                                oto_only_count += 1
+                            elif int_value == 2:
+                                referral_only_count += 1
+                            elif int_value == 3:
+                                both_count += 1
+                            else:
+                                # Any other value counts as neither
+                                neither_count += 1
+
+                    summaries['neither'][member] = neither_count
+                    summaries['oto_only'][member] = oto_only_count
+                    summaries['referral_only'][member] = referral_only_count
+                    summaries['both'][member] = both_count
+
+                result['summaries'] = summaries
+
+            return Response(result)
+
+        except (Chapter.DoesNotExist, MonthlyReport.DoesNotExist):
+            return Response(
+                {'error': 'Chapter or monthly report not found'},
+                status=status.HTTP_404_NOT_FOUND
+            )
+        except Exception as e:
+            return Response(
+                {'error': f'Matrix generation failed: {str(e)}'},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
+
+class ComparisonViewSet(viewsets.ViewSet):
+    """
+    ViewSet for comparing monthly reports.
+
+    Provides endpoints for:
+    - Referral matrix comparison
+    - One-to-one matrix comparison
+    - Combination matrix comparison
+    - Comprehensive report comparison
+    """
+    permission_classes = [AllowAny]  # TODO: Add proper authentication
+
+    @action(detail=False, methods=['get'], url_path='referral')
+    def compare_referral(self, request, chapter_id=None, report_id=None, previous_report_id=None):
+        """
+        Compare referral matrices between two monthly reports.
+
+        Returns comparison data showing changes between reports.
+        """
+        try:
+            # Get both reports
+            current_report = MonthlyReport.objects.get(id=report_id, chapter_id=chapter_id)
+            previous_report = MonthlyReport.objects.get(id=previous_report_id, chapter_id=chapter_id)
+
+            # Perform comparison
+            comparison = ComparisonService.compare_referral_matrices(
+                current_report.referral_matrix_data,
+                previous_report.referral_matrix_data
+            )
+
+            return Response({
+                'current_report': {
+                    'id': current_report.id,
+                    'month_year': current_report.month_year
+                },
+                'previous_report': {
+                    'id': previous_report.id,
+                    'month_year': previous_report.month_year
+                },
+                'comparison': comparison
+            }, status=status.HTTP_200_OK)
+
+        except MonthlyReport.DoesNotExist:
+            return Response(
+                {'error': 'One or both reports not found'},
+                status=status.HTTP_404_NOT_FOUND
+            )
+        except Exception as e:
+            return Response(
+                {'error': f'Failed to compare referral matrices: {str(e)}'},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
+    @action(detail=False, methods=['get'], url_path='one-to-one')
+    def compare_oto(self, request, chapter_id=None, report_id=None, previous_report_id=None):
+        """
+        Compare one-to-one matrices between two monthly reports.
+
+        Returns comparison data showing changes in OTO activities.
+        """
+        try:
+            # Get both reports
+            current_report = MonthlyReport.objects.get(id=report_id, chapter_id=chapter_id)
+            previous_report = MonthlyReport.objects.get(id=previous_report_id, chapter_id=chapter_id)
+
+            # Perform comparison
+            comparison = ComparisonService.compare_oto_matrices(
+                current_report.oto_matrix_data,
+                previous_report.oto_matrix_data
+            )
+
+            return Response({
+                'current_report': {
+                    'id': current_report.id,
+                    'month_year': current_report.month_year
+                },
+                'previous_report': {
+                    'id': previous_report.id,
+                    'month_year': previous_report.month_year
+                },
+                'comparison': comparison
+            }, status=status.HTTP_200_OK)
+
+        except MonthlyReport.DoesNotExist:
+            return Response(
+                {'error': 'One or both reports not found'},
+                status=status.HTTP_404_NOT_FOUND
+            )
+        except Exception as e:
+            return Response(
+                {'error': f'Failed to compare one-to-one matrices: {str(e)}'},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
+    @action(detail=False, methods=['get'], url_path='combination')
+    def compare_combination(self, request, chapter_id=None, report_id=None, previous_report_id=None):
+        """
+        Compare combination matrices between two monthly reports.
+
+        Returns comparison showing changes in combined referral/OTO patterns.
+        """
+        try:
+            # Get both reports
+            current_report = MonthlyReport.objects.get(id=report_id, chapter_id=chapter_id)
+            previous_report = MonthlyReport.objects.get(id=previous_report_id, chapter_id=chapter_id)
+
+            # Perform comparison
+            comparison = ComparisonService.compare_combination_matrices(
+                current_report.combination_matrix_data,
+                previous_report.combination_matrix_data
+            )
+
+            return Response({
+                'current_report': {
+                    'id': current_report.id,
+                    'month_year': current_report.month_year
+                },
+                'previous_report': {
+                    'id': previous_report.id,
+                    'month_year': previous_report.month_year
+                },
+                'comparison': comparison
+            }, status=status.HTTP_200_OK)
+
+        except MonthlyReport.DoesNotExist:
+            return Response(
+                {'error': 'One or both reports not found'},
+                status=status.HTTP_404_NOT_FOUND
+            )
+        except Exception as e:
+            return Response(
+                {'error': f'Failed to compare combination matrices: {str(e)}'},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
+    @action(detail=False, methods=['get'], url_path='comprehensive')
+    def compare_comprehensive(self, request, chapter_id=None, report_id=None, previous_report_id=None):
+        """
+        Get comprehensive comparison between two monthly reports.
+
+        Includes all matrices and insights across referrals, OTOs, and combinations.
+        """
+        try:
+            # Get both reports
+            current_report = MonthlyReport.objects.get(id=report_id, chapter_id=chapter_id)
+            previous_report = MonthlyReport.objects.get(id=previous_report_id, chapter_id=chapter_id)
+
+            # Perform comprehensive comparison
+            comparison_data = ComparisonService.compare_monthly_reports(
+                current_report,
+                previous_report
+            )
+
+            return Response(comparison_data, status=status.HTTP_200_OK)
+
+        except MonthlyReport.DoesNotExist:
+            return Response(
+                {'error': 'One or both reports not found'},
+                status=status.HTTP_404_NOT_FOUND
+            )
+        except ValueError as e:
+            return Response(
+                {'error': str(e)},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+        except Exception as e:
+            return Response(
+                {'error': f'Failed to compare reports: {str(e)}'},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )

--- a/backend/chapters/views.py
+++ b/backend/chapters/views.py
@@ -1,3 +1,229 @@
-from django.shortcuts import render
+"""
+Chapter ViewSet - RESTful API for Chapter management
+"""
+from django.db import models
+from rest_framework import viewsets, status
+from rest_framework.decorators import action
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
 
-# Create your views here.
+from chapters.models import Chapter
+from members.models import Member
+from analytics.models import Referral, OneToOne, TYFCB
+from bni.serializers import ChapterSerializer
+from bni.services.chapter_service import ChapterService
+
+
+class ChapterViewSet(viewsets.ModelViewSet):
+    """
+    ViewSet for Chapter CRUD operations and dashboard.
+
+    Provides:
+    - list: Dashboard with all chapters and statistics
+    - retrieve: Detailed chapter information with members
+    - create: Create new chapter
+    - destroy: Delete chapter and all members
+    """
+    queryset = Chapter.objects.all()
+    serializer_class = ChapterSerializer
+    permission_classes = [AllowAny]  # TODO: Add proper authentication
+
+    def list(self, request):
+        """
+        Get dashboard data for all chapters.
+
+        Returns comprehensive statistics including:
+        - Total members, referrals, one-to-ones, TYFCB amounts
+        - Averages per member
+        - Member lists
+        """
+        chapters = self.get_queryset()
+        chapter_data = []
+
+        for chapter in chapters:
+            members = Member.objects.filter(chapter=chapter, is_active=True)
+            member_count = members.count()
+
+            # Calculate totals
+            total_referrals = Referral.objects.filter(giver__chapter=chapter).count()
+            total_one_to_ones = OneToOne.objects.filter(member1__chapter=chapter).count()
+            total_tyfcb_inside = float(
+                TYFCB.objects.filter(
+                    receiver__chapter=chapter,
+                    within_chapter=True
+                ).aggregate(total=models.Sum('amount'))['total'] or 0
+            )
+            total_tyfcb_outside = float(
+                TYFCB.objects.filter(
+                    receiver__chapter=chapter,
+                    within_chapter=False
+                ).aggregate(total=models.Sum('amount'))['total'] or 0
+            )
+
+            # Calculate averages
+            avg_referrals = round(total_referrals / member_count, 2) if member_count > 0 else 0
+            avg_one_to_ones = round(total_one_to_ones / member_count, 2) if member_count > 0 else 0
+            avg_tyfcb_inside = round(total_tyfcb_inside / member_count, 2) if member_count > 0 else 0
+            avg_tyfcb_outside = round(total_tyfcb_outside / member_count, 2) if member_count > 0 else 0
+
+            # Prepare member list
+            member_list = []
+            for member in members:
+                member_list.append({
+                    'id': member.id,
+                    'name': member.full_name,
+                    'business_name': member.business_name,
+                    'classification': member.classification,
+                    'email': member.email,
+                    'phone': member.phone,
+                })
+
+            chapter_data.append({
+                'id': chapter.id,
+                'name': chapter.name,
+                'location': chapter.location,
+                'meeting_day': chapter.meeting_day,
+                'meeting_time': str(chapter.meeting_time) if chapter.meeting_time else None,
+                'total_members': member_count,
+                'total_referrals': total_referrals,
+                'total_one_to_ones': total_one_to_ones,
+                'total_tyfcb_inside': total_tyfcb_inside,
+                'total_tyfcb_outside': total_tyfcb_outside,
+                'avg_referrals_per_member': avg_referrals,
+                'avg_one_to_ones_per_member': avg_one_to_ones,
+                'avg_tyfcb_inside_per_member': avg_tyfcb_inside,
+                'avg_tyfcb_outside_per_member': avg_tyfcb_outside,
+                'members': member_list,
+            })
+
+        return Response(chapter_data)
+
+    def retrieve(self, request, pk=None):
+        """
+        Get detailed information for a specific chapter.
+
+        Returns chapter details with all active members and their full information.
+        """
+        try:
+            chapter = self.get_object()
+        except Chapter.DoesNotExist:
+            return Response(
+                {'error': 'Chapter not found'},
+                status=status.HTTP_404_NOT_FOUND
+            )
+
+        # Get all active members
+        members = Member.objects.filter(chapter=chapter, is_active=True)
+
+        # Calculate performance metrics
+        total_referrals = Referral.objects.filter(giver__chapter=chapter).count()
+        total_one_to_ones = OneToOne.objects.filter(member1__chapter=chapter).count()
+        total_tyfcb = float(
+            TYFCB.objects.filter(
+                receiver__chapter=chapter
+            ).aggregate(total=models.Sum('amount'))['total'] or 0
+        )
+
+        # Prepare member details
+        member_details = []
+        for member in members:
+            # Get individual member stats
+            referrals_given = Referral.objects.filter(giver=member).count()
+            referrals_received = Referral.objects.filter(receiver=member).count()
+            otos = OneToOne.objects.filter(
+                models.Q(member1=member) | models.Q(member2=member)
+            ).count()
+            tyfcb_received = float(
+                TYFCB.objects.filter(receiver=member).aggregate(
+                    total=models.Sum('amount')
+                )['total'] or 0
+            )
+
+            member_details.append({
+                'id': member.id,
+                'first_name': member.first_name,
+                'last_name': member.last_name,
+                'full_name': member.full_name,
+                'business_name': member.business_name,
+                'classification': member.classification,
+                'email': member.email,
+                'phone': member.phone,
+                'is_active': member.is_active,
+                'joined_date': member.joined_date,
+                'referrals_given': referrals_given,
+                'referrals_received': referrals_received,
+                'one_to_ones': otos,
+                'tyfcb_received': tyfcb_received,
+            })
+
+        chapter_data = {
+            'id': chapter.id,
+            'name': chapter.name,
+            'location': chapter.location,
+            'meeting_day': chapter.meeting_day,
+            'meeting_time': str(chapter.meeting_time) if chapter.meeting_time else None,
+            'created_at': chapter.created_at,
+            'updated_at': chapter.updated_at,
+            'total_members': members.count(),
+            'total_referrals': total_referrals,
+            'total_one_to_ones': total_one_to_ones,
+            'total_tyfcb': total_tyfcb,
+            'members': member_details,
+        }
+
+        return Response(chapter_data)
+
+    def create(self, request):
+        """
+        Create a new chapter.
+
+        Uses ChapterService for centralized chapter creation logic.
+        Returns 201 if created, 200 if already exists.
+        """
+        name = request.data.get('name')
+        if not name:
+            return Response(
+                {'error': 'Chapter name is required'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        location = request.data.get('location', 'Dubai')
+        meeting_day = request.data.get('meeting_day', '')
+        meeting_time = request.data.get('meeting_time')
+
+        service = ChapterService()
+        chapter, created = service.get_or_create_chapter(
+            name=name,
+            location=location,
+            meeting_day=meeting_day,
+            meeting_time=meeting_time
+        )
+
+        serializer = self.get_serializer(chapter)
+        return Response(
+            serializer.data,
+            status=status.HTTP_201_CREATED if created else status.HTTP_200_OK
+        )
+
+    def destroy(self, request, pk=None):
+        """
+        Delete a chapter and all associated members.
+
+        Uses ChapterService for centralized deletion logic.
+        Returns count of deleted members.
+        """
+        try:
+            chapter = self.get_object()
+        except Chapter.DoesNotExist:
+            return Response(
+                {'error': 'Chapter not found'},
+                status=status.HTTP_404_NOT_FOUND
+            )
+
+        service = ChapterService()
+        result = service.delete_chapter(chapter.id)
+
+        return Response({
+            'message': f"Chapter '{chapter.name}' deleted successfully",
+            'members_deleted': result['members_deleted']
+        })

--- a/backend/members/views.py
+++ b/backend/members/views.py
@@ -1,3 +1,286 @@
-from django.shortcuts import render
+"""
+Member ViewSet - RESTful API for Member management
+"""
+from urllib.parse import unquote
+from django.db import models
+from rest_framework import viewsets, status
+from rest_framework.decorators import action
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
 
-# Create your views here.
+from chapters.models import Chapter
+from members.models import Member
+from analytics.models import Referral, OneToOne, TYFCB
+from bni.serializers import MemberSerializer, MemberCreateSerializer, MemberUpdateSerializer
+from bni.services.member_service import MemberService
+
+
+class MemberViewSet(viewsets.ModelViewSet):
+    """
+    ViewSet for Member CRUD operations and analytics.
+
+    Nested under /api/chapters/{chapter_id}/members/
+    """
+    serializer_class = MemberSerializer
+    permission_classes = [AllowAny]  # TODO: Add proper authentication
+
+    def get_queryset(self):
+        """Filter members by chapter from URL."""
+        chapter_id = self.kwargs.get('chapter_pk')
+        if chapter_id:
+            return Member.objects.filter(chapter_id=chapter_id, is_active=True)
+        return Member.objects.filter(is_active=True)
+
+    def get_serializer_class(self):
+        """Use different serializers for create/update."""
+        if self.action == 'create':
+            return MemberCreateSerializer
+        elif self.action in ['update', 'partial_update']:
+            return MemberUpdateSerializer
+        return MemberSerializer
+
+    def create(self, request, chapter_pk=None):
+        """Create a new member in the specified chapter."""
+        try:
+            chapter = Chapter.objects.get(id=chapter_pk)
+        except Chapter.DoesNotExist:
+            return Response(
+                {'error': 'Chapter not found'},
+                status=status.HTTP_404_NOT_FOUND
+            )
+
+        # Validate required fields
+        first_name = request.data.get('first_name')
+        last_name = request.data.get('last_name')
+
+        if not first_name or not last_name:
+            return Response(
+                {'error': 'first_name and last_name are required'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        # Use MemberService to create member
+        service = MemberService()
+        member, created = service.get_or_create_member(
+            chapter=chapter,
+            first_name=first_name,
+            last_name=last_name,
+            business_name=request.data.get('business_name', ''),
+            classification=request.data.get('classification', ''),
+            email=request.data.get('email', ''),
+            phone=request.data.get('phone', ''),
+            is_active=request.data.get('is_active', True),
+            joined_date=request.data.get('joined_date')
+        )
+
+        serializer = MemberSerializer(member)
+        return Response(
+            serializer.data,
+            status=status.HTTP_201_CREATED if created else status.HTTP_200_OK
+        )
+
+    def update(self, request, pk=None, chapter_pk=None):
+        """Update member information."""
+        try:
+            member = Member.objects.get(id=pk, chapter_id=chapter_pk)
+        except Member.DoesNotExist:
+            return Response(
+                {'error': 'Member not found in this chapter'},
+                status=status.HTTP_404_NOT_FOUND
+            )
+
+        # Use MemberService to update
+        service = MemberService()
+        updated_member = service.update_member(member.id, request.data)
+
+        serializer = MemberSerializer(updated_member)
+        return Response(serializer.data)
+
+    def partial_update(self, request, pk=None, chapter_pk=None):
+        """Partially update member information."""
+        return self.update(request, pk, chapter_pk)
+
+    def destroy(self, request, pk=None, chapter_pk=None):
+        """Delete a member and all associated data."""
+        try:
+            member = Member.objects.get(id=pk, chapter_id=chapter_pk)
+        except Member.DoesNotExist:
+            return Response(
+                {'error': 'Member not found in this chapter'},
+                status=status.HTTP_404_NOT_FOUND
+            )
+
+        # Use MemberService to delete
+        service = MemberService()
+        result = service.delete_member(member.id)
+
+        return Response({
+            'message': f"Member '{member.full_name}' deleted successfully",
+            'referrals_deleted': result['referrals_deleted'],
+            'one_to_ones_deleted': result['one_to_ones_deleted'],
+            'tyfcbs_deleted': result['tyfcbs_deleted']
+        })
+
+    @action(detail=False, methods=['get'], url_path='(?P<member_name>[^/.]+)/analytics')
+    def analytics(self, request, chapter_pk=None, member_name=None):
+        """
+        Get comprehensive analytics for a member.
+
+        URL: /api/chapters/{chapter_id}/members/{member_name}/analytics/
+        """
+        # URL decode the member name
+        member_name = unquote(member_name)
+
+        try:
+            chapter = Chapter.objects.get(id=chapter_pk)
+        except Chapter.DoesNotExist:
+            return Response(
+                {'error': 'Chapter not found'},
+                status=status.HTTP_404_NOT_FOUND
+            )
+
+        # Find member by name (case insensitive)
+        normalized_name = Member.normalize_name(member_name)
+        try:
+            member = Member.objects.get(chapter=chapter, normalized_name=normalized_name)
+        except Member.DoesNotExist:
+            return Response(
+                {'error': f'Member "{member_name}" not found in this chapter'},
+                status=status.HTTP_404_NOT_FOUND
+            )
+
+        # Get all chapter members for gap analysis
+        all_members = Member.objects.filter(chapter=chapter, is_active=True).exclude(id=member.id)
+        total_members = all_members.count()
+
+        # Calculate performance metrics
+        referrals_given = Referral.objects.filter(giver=member).count()
+        referrals_received = Referral.objects.filter(receiver=member).count()
+
+        # Get one-to-ones
+        otos = OneToOne.objects.filter(
+            models.Q(member1=member) | models.Q(member2=member)
+        )
+        oto_count = otos.count()
+
+        # Get unique OTO partners
+        oto_partners = set()
+        for oto in otos:
+            partner = oto.member2 if oto.member1 == member else oto.member1
+            oto_partners.add(partner.id)
+
+        # Get referral relationships
+        referral_givers = set(Referral.objects.filter(receiver=member).values_list('giver_id', flat=True))
+        referral_receivers = set(Referral.objects.filter(giver=member).values_list('receiver_id', flat=True))
+
+        # Get TYFCB data
+        tyfcb_received = TYFCB.objects.filter(receiver=member)
+        total_tyfcb = float(tyfcb_received.aggregate(total=models.Sum('amount'))['total'] or 0)
+        tyfcb_inside = float(
+            tyfcb_received.filter(within_chapter=True).aggregate(total=models.Sum('amount'))['total'] or 0
+        )
+        tyfcb_outside = float(
+            tyfcb_received.filter(within_chapter=False).aggregate(total=models.Sum('amount'))['total'] or 0
+        )
+
+        # Calculate gaps
+        all_member_ids = set(all_members.values_list('id', flat=True))
+        missing_otos = all_member_ids - oto_partners
+        missing_referrals_given = all_member_ids - referral_receivers
+        missing_referrals_received = all_member_ids - referral_givers
+
+        # Find priority connections (in multiple missing lists)
+        priority_connections = (
+            (missing_otos & missing_referrals_given) |
+            (missing_otos & missing_referrals_received) |
+            (missing_referrals_given & missing_referrals_received)
+        )
+
+        # Get member details for priority connections
+        priority_members = []
+        for member_id in priority_connections:
+            m = Member.objects.get(id=member_id)
+            priority_members.append({
+                'id': m.id,
+                'name': m.full_name,
+                'business_name': m.business_name,
+                'classification': m.classification
+            })
+
+        # Calculate completion rates
+        oto_completion = round((oto_count / total_members * 100), 1) if total_members > 0 else 0
+        referral_completion = round((len(referral_receivers) / total_members * 100), 1) if total_members > 0 else 0
+
+        # Performance scores
+        oto_score = min(100, round((oto_count / total_members) * 100, 1)) if total_members > 0 else 0
+        referral_score = min(100, round((referrals_given / total_members) * 50, 1)) if total_members > 0 else 0
+        tyfcb_score = min(100, round(total_tyfcb / 1000, 1))  # Score based on AED amounts
+        overall_score = round((oto_score + referral_score + tyfcb_score) / 3, 1)
+
+        # Generate AI recommendations
+        recommendations = []
+        if oto_completion < 50:
+            recommendations.append({
+                'type': 'warning',
+                'category': 'one_to_ones',
+                'message': f'Low 1-2-1 completion rate ({oto_completion}%). Focus on scheduling more meetings.',
+                'priority': 'high'
+            })
+
+        if len(priority_connections) > 0:
+            recommendations.append({
+                'type': 'action',
+                'category': 'priority_connections',
+                'message': f'Connect with {len(priority_connections)} priority members to maximize impact.',
+                'priority': 'high'
+            })
+
+        if referrals_given < total_members * 0.5:
+            recommendations.append({
+                'type': 'warning',
+                'category': 'referrals',
+                'message': 'Increase referral giving to strengthen relationships.',
+                'priority': 'medium'
+            })
+
+        if overall_score >= 80:
+            recommendations.append({
+                'type': 'success',
+                'category': 'performance',
+                'message': 'Excellent performance! Keep up the great networking.',
+                'priority': 'low'
+            })
+
+        return Response({
+            'member': {
+                'id': member.id,
+                'name': member.full_name,
+                'business_name': member.business_name,
+                'classification': member.classification
+            },
+            'performance': {
+                'referrals_given': referrals_given,
+                'referrals_received': referrals_received,
+                'one_to_ones': oto_count,
+                'tyfcb_total': total_tyfcb,
+                'tyfcb_inside': tyfcb_inside,
+                'tyfcb_outside': tyfcb_outside
+            },
+            'scores': {
+                'overall': overall_score,
+                'one_to_one': oto_score,
+                'referral': referral_score,
+                'tyfcb': tyfcb_score
+            },
+            'completion_rates': {
+                'one_to_ones': oto_completion,
+                'referrals': referral_completion
+            },
+            'gaps': {
+                'missing_otos': list(missing_otos),
+                'missing_referrals_given': list(missing_referrals_given),
+                'missing_referrals_received': list(missing_referrals_received),
+                'priority_connections': priority_members
+            },
+            'recommendations': recommendations
+        })

--- a/backend/reports/views.py
+++ b/backend/reports/views.py
@@ -1,3 +1,241 @@
-from django.shortcuts import render
+"""
+MonthlyReport ViewSet - RESTful API for Monthly Report management
+"""
+from rest_framework import viewsets, status
+from rest_framework.decorators import action
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
 
-# Create your views here.
+from chapters.models import Chapter
+from members.models import Member
+from reports.models import MonthlyReport, MemberMonthlyStats
+
+
+class MonthlyReportViewSet(viewsets.ModelViewSet):
+    """
+    ViewSet for MonthlyReport operations.
+
+    Provides:
+    - list: Get all monthly reports for a chapter
+    - destroy: Delete a monthly report
+    - member_detail: Get detailed member information with missing interaction lists
+    - tyfcb_data: Get TYFCB data for a specific report
+    """
+    queryset = MonthlyReport.objects.all()
+    permission_classes = [AllowAny]  # TODO: Add proper authentication
+
+    def list(self, request, chapter_id=None):
+        """
+        Get all monthly reports for a specific chapter.
+
+        Returns list of monthly reports with metadata including:
+        - Report IDs and dates
+        - File information
+        - Matrix availability flags
+        """
+        try:
+            chapter = Chapter.objects.get(id=chapter_id)
+            monthly_reports = MonthlyReport.objects.filter(chapter=chapter).order_by('-month_year')
+
+            result = []
+            for report in monthly_reports:
+                result.append({
+                    'id': report.id,
+                    'month_year': report.month_year,
+                    'uploaded_at': report.uploaded_at,
+                    'processed_at': report.processed_at,
+                    'slip_audit_file': report.slip_audit_file.name if report.slip_audit_file else None,
+                    'member_names_file': report.member_names_file.name if report.member_names_file else None,
+                    'has_referral_matrix': bool(report.referral_matrix_data),
+                    'has_oto_matrix': bool(report.oto_matrix_data),
+                    'has_combination_matrix': bool(report.combination_matrix_data)
+                })
+
+            return Response(result)
+
+        except Chapter.DoesNotExist:
+            return Response(
+                {'error': 'Chapter not found'},
+                status=status.HTTP_404_NOT_FOUND
+            )
+        except Exception as e:
+            return Response(
+                {'error': f'Monthly reports retrieval failed: {str(e)}'},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
+    def destroy(self, request, pk=None, chapter_id=None):
+        """
+        Delete a monthly report.
+
+        Also deletes associated files from storage.
+        Requires authentication.
+        """
+        # Override permission for this specific action
+        if not request.user.is_authenticated:
+            return Response(
+                {'error': 'Authentication required'},
+                status=status.HTTP_401_UNAUTHORIZED
+            )
+
+        try:
+            chapter = Chapter.objects.get(id=chapter_id)
+            monthly_report = MonthlyReport.objects.get(id=pk, chapter=chapter)
+
+            # Delete associated files
+            if monthly_report.slip_audit_file:
+                monthly_report.slip_audit_file.delete(save=False)
+            if monthly_report.member_names_file:
+                monthly_report.member_names_file.delete(save=False)
+
+            # Delete the report
+            monthly_report.delete()
+
+            return Response({'message': 'Monthly report deleted successfully'})
+
+        except (Chapter.DoesNotExist, MonthlyReport.DoesNotExist):
+            return Response(
+                {'error': 'Chapter or monthly report not found'},
+                status=status.HTTP_404_NOT_FOUND
+            )
+        except Exception as e:
+            return Response(
+                {'error': f'Monthly report deletion failed: {str(e)}'},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
+    @action(detail=True, methods=['get'], url_path='members/(?P<member_id>[^/.]+)')
+    def member_detail(self, request, pk=None, chapter_id=None, member_id=None):
+        """
+        Get detailed member information including missing interaction lists.
+
+        Returns member stats and lists of:
+        - Missing one-to-ones
+        - Missing referrals (given and received)
+        - Priority connections (members appearing in multiple missing lists)
+        """
+        try:
+            chapter = Chapter.objects.get(id=chapter_id)
+            monthly_report = MonthlyReport.objects.get(id=pk, chapter=chapter)
+            member = Member.objects.get(id=member_id, chapter=chapter)
+
+            try:
+                member_stats = MemberMonthlyStats.objects.get(
+                    member=member,
+                    monthly_report=monthly_report
+                )
+            except MemberMonthlyStats.DoesNotExist:
+                # If no stats exist, return basic member info with empty lists
+                member_stats = None
+
+            # Get all chapter members for name resolution
+            chapter_members = Member.objects.filter(chapter=chapter, is_active=True)
+            member_lookup = {m.id: m.full_name for m in chapter_members}
+
+            result = {
+                'member': {
+                    'id': member.id,
+                    'full_name': member.full_name,
+                    'first_name': member.first_name,
+                    'last_name': member.last_name,
+                    'business_name': member.business_name,
+                    'classification': member.classification,
+                    'email': member.email,
+                    'phone': member.phone
+                },
+                'stats': {
+                    'referrals_given': member_stats.referrals_given if member_stats else 0,
+                    'referrals_received': member_stats.referrals_received if member_stats else 0,
+                    'one_to_ones_completed': member_stats.one_to_ones_completed if member_stats else 0,
+                    'tyfcb_inside_amount': float(member_stats.tyfcb_inside_amount) if member_stats else 0.0,
+                    'tyfcb_outside_amount': float(member_stats.tyfcb_outside_amount) if member_stats else 0.0
+                },
+                'missing_interactions': {
+                    'missing_otos': [
+                        {
+                            'id': member_id,
+                            'name': member_lookup.get(member_id, 'Unknown')
+                        }
+                        for member_id in (member_stats.missing_otos if member_stats else [])
+                        if member_id in member_lookup
+                    ],
+                    'missing_referrals_given_to': [
+                        {
+                            'id': member_id,
+                            'name': member_lookup.get(member_id, 'Unknown')
+                        }
+                        for member_id in (member_stats.missing_referrals_given_to if member_stats else [])
+                        if member_id in member_lookup
+                    ],
+                    'missing_referrals_received_from': [
+                        {
+                            'id': member_id,
+                            'name': member_lookup.get(member_id, 'Unknown')
+                        }
+                        for member_id in (member_stats.missing_referrals_received_from if member_stats else [])
+                        if member_id in member_lookup
+                    ],
+                    'priority_connections': [
+                        {
+                            'id': member_id,
+                            'name': member_lookup.get(member_id, 'Unknown')
+                        }
+                        for member_id in (member_stats.priority_connections if member_stats else [])
+                        if member_id in member_lookup
+                    ]
+                },
+                'monthly_report': {
+                    'id': monthly_report.id,
+                    'month_year': monthly_report.month_year,
+                    'processed_at': monthly_report.processed_at
+                }
+            }
+
+            return Response(result)
+
+        except (Chapter.DoesNotExist, MonthlyReport.DoesNotExist, Member.DoesNotExist):
+            return Response(
+                {'error': 'Chapter, monthly report, or member not found'},
+                status=status.HTTP_404_NOT_FOUND
+            )
+        except Exception as e:
+            return Response(
+                {'error': f'Member detail retrieval failed: {str(e)}'},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
+    @action(detail=True, methods=['get'], url_path='tyfcb')
+    def tyfcb_data(self, request, pk=None, chapter_id=None):
+        """
+        Get TYFCB data for a specific monthly report.
+
+        Returns inside and outside TYFCB data with totals and per-member breakdowns.
+        """
+        try:
+            chapter = Chapter.objects.get(id=chapter_id)
+            monthly_report = MonthlyReport.objects.get(id=pk, chapter=chapter)
+
+            tyfcb_data = {
+                'inside': monthly_report.tyfcb_inside_data or {'total_amount': 0, 'count': 0, 'by_member': {}},
+                'outside': monthly_report.tyfcb_outside_data or {'total_amount': 0, 'count': 0, 'by_member': {}},
+                'month_year': monthly_report.month_year,
+                'processed_at': monthly_report.processed_at
+            }
+
+            return Response(tyfcb_data)
+
+        except Chapter.DoesNotExist:
+            return Response(
+                {'error': 'Chapter not found'},
+                status=status.HTTP_404_NOT_FOUND
+            )
+        except MonthlyReport.DoesNotExist:
+            return Response(
+                {'error': 'Monthly report not found'},
+                status=status.HTTP_404_NOT_FOUND
+            )
+        except Exception as e:
+            return Response(
+                {'error': f'Failed to get TYFCB data: {str(e)}'},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )

--- a/backend/uploads/views.py
+++ b/backend/uploads/views.py
@@ -1,3 +1,165 @@
-from django.shortcuts import render
+"""
+File Upload ViewSet - RESTful API for Excel file uploads
+"""
+import logging
+from rest_framework import viewsets, status, serializers
+from rest_framework.decorators import action
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.parsers import MultiPartParser, FormParser
 
-# Create your views here.
+from chapters.models import Chapter
+from bni.services.excel_processor import ExcelProcessorService
+from bni.services.bulk_upload_service import BulkUploadService
+
+logger = logging.getLogger(__name__)
+
+
+class FileUploadSerializer(serializers.Serializer):
+    """Serializer for file upload validation."""
+    slip_audit_file = serializers.FileField()
+    member_names_file = serializers.FileField(required=False)
+    chapter_id = serializers.IntegerField()
+    month_year = serializers.CharField(max_length=7, help_text="e.g., '2024-06'")
+    upload_option = serializers.ChoiceField(choices=['slip_only', 'slip_and_members'], default='slip_only')
+
+
+class FileUploadViewSet(viewsets.ViewSet):
+    """
+    ViewSet for file upload operations.
+
+    Provides endpoints for:
+    - Excel file upload: Process slip audit and member names files
+    - Bulk upload: Process Regional PALMS Summary reports
+    """
+    parser_classes = (MultiPartParser, FormParser)
+    permission_classes = [AllowAny]  # TODO: Add proper authentication
+
+    @action(detail=False, methods=['post'], url_path='excel')
+    def upload_excel(self, request):
+        """
+        Handle Excel file upload and processing.
+
+        Accepts:
+        - slip_audit_file: Required Excel file (.xls/.xlsx)
+        - member_names_file: Optional Excel file for member names
+        - chapter_id: Chapter to associate with
+        - month_year: Report month in format 'YYYY-MM'
+        - upload_option: 'slip_only' or 'slip_and_members'
+
+        Returns processing result with created records and any errors.
+        """
+        serializer = FileUploadSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(
+                {'error': 'Invalid data', 'details': serializer.errors},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        try:
+            # Get validated data
+            slip_audit_file = serializer.validated_data['slip_audit_file']
+            member_names_file = serializer.validated_data.get('member_names_file')
+            chapter_id = serializer.validated_data['chapter_id']
+            month_year = serializer.validated_data['month_year']
+            upload_option = serializer.validated_data['upload_option']
+
+            # Validate chapter access
+            try:
+                chapter = Chapter.objects.get(id=chapter_id)
+                # Add permission check here if needed
+            except Chapter.DoesNotExist:
+                return Response(
+                    {'error': 'Chapter not found'},
+                    status=status.HTTP_404_NOT_FOUND
+                )
+
+            # Validate file types
+            if not slip_audit_file.name.lower().endswith(('.xls', '.xlsx')):
+                return Response(
+                    {'error': 'Only .xls and .xlsx files are supported for slip audit file'},
+                    status=status.HTTP_400_BAD_REQUEST
+                )
+
+            if member_names_file and not member_names_file.name.lower().endswith(('.xls', '.xlsx')):
+                return Response(
+                    {'error': 'Only .xls and .xlsx files are supported for member names file'},
+                    status=status.HTTP_400_BAD_REQUEST
+                )
+
+            # Process using the new monthly report method
+            processor = ExcelProcessorService(chapter)
+            result = processor.process_monthly_report(
+                slip_audit_file=slip_audit_file,
+                member_names_file=member_names_file,
+                month_year=month_year
+            )
+
+            return Response(result, status=status.HTTP_200_OK)
+
+        except Exception as e:
+            return Response(
+                {'error': f'Processing failed: {str(e)}'},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
+    @action(detail=False, methods=['post'], url_path='bulk')
+    def bulk_upload(self, request):
+        """
+        Handle Regional PALMS Summary bulk upload.
+
+        Accepts:
+        - file: Excel file containing regional summary data
+
+        Processes the file and creates/updates multiple chapters and members.
+        Returns summary of operations performed.
+        """
+        if 'file' not in request.FILES:
+            return Response(
+                {'error': 'No file provided'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        file = request.FILES['file']
+
+        # Validate file type
+        if not file.name.endswith(('.xls', '.xlsx')):
+            return Response(
+                {'error': 'Invalid file type. Please upload .xls or .xlsx file'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        try:
+            # Process the file
+            service = BulkUploadService()
+            result = service.process_region_summary(file)
+
+            if result['success']:
+                return Response({
+                    'success': True,
+                    'message': 'Bulk upload completed successfully',
+                    'details': {
+                        'chapters_created': result['chapters_created'],
+                        'chapters_updated': result['chapters_updated'],
+                        'members_created': result['members_created'],
+                        'members_updated': result['members_updated'],
+                        'total_processed': result['total_processed'],
+                        'warnings': result['warnings']
+                    }
+                }, status=status.HTTP_200_OK)
+            else:
+                return Response({
+                    'success': False,
+                    'message': result.get('error', 'Processing failed'),
+                    'details': {
+                        'errors': result.get('errors', []),
+                        'warnings': result.get('warnings', [])
+                    }
+                }, status=status.HTTP_400_BAD_REQUEST)
+
+        except Exception as e:
+            logger.exception("Error in bulk upload")
+            return Response(
+                {'error': f'Processing failed: {str(e)}'},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )


### PR DESCRIPTION
## Summary
Phase 2 of backend refactoring: Convert all function-based views to Django REST Framework ViewSets with proper RESTful routing.

This builds on Phase 1 (feature-based app structure) and completes the ViewSet migration.

## Changes

### ViewSets Created
- **ChapterViewSet** - Full CRUD + dashboard with chapter statistics
- **MemberViewSet** - Full CRUD nested under chapters + analytics action with gap analysis
- **MonthlyReportViewSet** - List/delete operations + member_detail and tyfcb_data actions
- **MatrixViewSet** - Referral, one-to-one, and combination matrix generation actions
- **ComparisonViewSet** - Comprehensive matrix comparison actions between reports
- **FileUploadViewSet** - Excel upload and bulk upload actions with file processing

### URL Routing Refactor
- Refactored `bni/urls.py` to use DRF DefaultRouter
- Set up nested routes for chapters → members and chapters → reports
- Maintained backward compatibility with existing API endpoints
- All 80+ URL patterns properly registered and tested

### Code Quality
- All ViewSets follow DRF best practices
- Comprehensive docstrings for all methods
- Preserved all existing business logic
- Error handling consistent across ViewSets
- Uses service layer pattern (ChapterService, MemberService, etc.)

## Statistics
- 6 files modified
- 1,414 lines added (ViewSet implementations)
- 69 lines removed (old URL patterns)
- All Django checks passing

## Testing
- Django system check: ✓ No errors
- URL patterns validated: ✓ 80+ endpoints registered
- Backward compatibility: ✓ Maintained

## Next Steps
After merge:
- Phase 3: Split ExcelProcessor into focused classes
- Phase 4: Implement custom exceptions
- Phase 5: Add structured logging system

Generated with [Claude Code](https://claude.com/claude-code)